### PR TITLE
Namespace support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 29
+    namespace = "edu.ucsd.WifiConnection"
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
Added namespace support as required by Flutter ^3.27.0

`namespace = "edu.ucsd.WifiConnection"`